### PR TITLE
Keep only the most recently spawned lint task for each file

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -37,7 +37,7 @@ export class DiagnosticProvider {
         return execution.processString(cmd, args, {
             cwd: path.dirname(document.uri.fsPath),
             maxBuffer: luacheck.getConf<number>('maxBuffer', 256 * 1024)
-        }, document.getText()).then((result) => result.stdout);
+        }, document.getText(), document.uri.fsPath).then((result) => result.stdout);
     }
 
     parseDiagnostic(document: vscode.TextDocument, data: string): vscode.Diagnostic[] {

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -28,7 +28,7 @@ export class DiagnosticProvider {
                         'The buffer size can be increased using `luacheck.maxBuffer`. '
                     );
                 }
-                return [];
+                throw e;
             });
     }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -21,10 +21,23 @@ export interface FailedExecution {
     result?: Result;
 }
 
-export function processString(cmd: string, args: string[], opt: Option, input: string): Thenable<Result> {
+// for any filename, keep only the most recently spawned process
+const procMap = new Map<string, child_process.ChildProcess>();
+
+export function processString(cmd: string, args: string[], opt: Option, input: string, filename: string): Thenable<Result> {
     return new Promise((resolve, reject) => {
         let proc = child_process.execFile(cmd, args, opt,
             (error, stdout, stderr) => {
+                // reject if cancelled
+                if (procMap.get(filename) !== proc) {
+                    reject(<FailedExecution>{
+                        errorCode: ErrorCode.Cancel,
+                        result: <Result>{ error, stdout, stderr }
+                    });
+                    return;
+                }
+                procMap.delete(filename);
+
                 if (error != null && error.message === 'stdout maxBuffer exceeded.') {
                     reject(<FailedExecution>{
                         errorCode: ErrorCode.BufferLimitExceed,
@@ -35,5 +48,12 @@ export function processString(cmd: string, args: string[], opt: Option, input: s
                 }
             });
         proc.stdin!.end(input);
+
+        // kill previous spawned process if exist
+        const prevProc = procMap.get(filename);
+        procMap.set(filename, proc);
+        if (prevProc !== undefined) {
+            prevProc.kill();
+        }
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as configuration from './configuration';
+import * as execution from './execution';
 
 import { DiagnosticProvider } from './diagnostic';
 
@@ -19,7 +20,11 @@ function registerDiagnosticProvider(selector: vscode.DocumentSelector, provider:
     let lint = (document: vscode.TextDocument) => {
         if (vscode.languages.match(selector, document)) {
             const uri = document.uri;
-            provider.provideDiagnostic(document).then((diagnostics) => collection.set(uri, diagnostics));
+            provider.provideDiagnostic(document).then((diagnostics) => collection.set(uri, diagnostics),
+                (e: execution.FailedExecution) => {
+                    // retain existing diagnostics when cancelled or error
+                    return;
+                });
         }
     };
     vscode.workspace.onDidChangeTextDocument(change => lint(change.document), null, subscriptions);


### PR DESCRIPTION
This pull request aimed to fix #5. To tackle that performance issue, I've created a process map that associates each filename with its most recently spawned linter process and terminates any previous instances if they exist. This approach ensures that each file will, at most, have a single linter process running.

I have included two gifs to illustrate the impact of the changes:
- Prior to the modification, each edit to the file triggers a new `luacheck` process. In the case of larger files, numerous `luacheck` processes are spawned, leading to CPU usage spiking up to 100% and causing severe system lag.
![spawn_too_many_processes](https://github.com/dwenegar/vscode-luacheck/assets/16996876/663bbfd4-3d7f-40ff-8343-29c57f17bb3e)

- After implementing the change, only the most recent `luacheck` process remains active, resulting in normal CPU usage.
![spawn_single_process](https://github.com/dwenegar/vscode-luacheck/assets/16996876/028bd200-a01d-41da-b18f-5f4c956385bf)

I am eager to have this pull request reviewed and merged promptly. :smile: